### PR TITLE
Fix: make "from the blog" bg light

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -474,7 +474,7 @@
 
     <div class="relative px-1 pt-8 pb-4 bg-transparent lg:px-8 lg:pt-12 lg:mb-4 md:mt-12">
         <div class="absolute inset-0">
-            <div class="bg-gray-900 dark:bg-gray-900/50 h-1/3 sm:h-2/3"></div>
+            <div class="bg-gray-200 dark:bg-gray-900/50 h-1/3 sm:h-2/3"></div>
         </div>
         <div class="relative px-2 mx-auto max-w-7xl">
             <div class="text-center">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -482,7 +482,7 @@
                     class="text-3xl font-black tracking-tight text-indigo-500 capitalize dark:text-indigo-300 sm:text-4xl">
                     From the blog
                 </h2>
-                <p class="max-w-2xl mx-auto mt-3 text-xl text-gray-200 sm:mt-4">Lorem ipsum dolor
+                <p class="max-w-2xl mx-auto mt-3 text-xl text-gray-500 dark:text-gray-300 sm:mt-4">Lorem ipsum dolor
                     sit amet consectetur,
                     adipisicing elit. Ipsa libero labore natus atque, ducimus sed.</p>
             </div>


### PR DESCRIPTION
The "From the blog" section was dark even on light theme. Now it uses the same background color as the hero.