### PR TITLE
Improve flow with smaller displays

### DIFF
--- a/layouts/partials/posts-template.html
+++ b/layouts/partials/posts-template.html
@@ -25,11 +25,13 @@
                     </div>
                     <div class="flex pt-6 font-medium text-primary-600 dark:text-primary-100 text-md">
                         <span class="pr-2 font-black">Tags:</span>
+                        <span>
                         {{ range $elem_index, $elem_val := (.GetTerms "tags") }}
                         {{- if gt $elem_index 0 }}, {{ end -}}
                         <a href="{{ .Permalink }}"
                            class="inline-flex items-center rounded-md bg-gray-300 hover:bg-primary-200 hover:text-black px-2.5 py-0.5 text-sm font-medium text-gray-900 capitalize">{{ .LinkTitle }}</a>
                         {{- end -}}
+                        </span>
                     </div>
                     <div class="flex items-center mt-6">
                         <div class="flex-shrink-0">


### PR DESCRIPTION
As box shrinks, tags get clipped. Containing within a span improves their flow, preventing clipping.