### PR TITLE
Fix WARN deprecated: .Site.IsServer was deprecated in Hugo v0.120.0

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -18,7 +18,7 @@
     }
 </script>
 {{ $styles := resources.Get "/css/style.css" | postCSS }}
-{{ if .Site.IsServer }}
+{{ if hugo.IsServer }}
 <link rel="stylesheet" href="{{ $styles.RelPermalink }}" />
 {{ else }}
 {{ $styles := $styles | minify | fingerprint | resources.PostProcess }}


### PR DESCRIPTION
Fixes
```
WARN  deprecated: .Site.IsServer was deprecated in Hugo v0.120.0 and will be removed in a future release. Use hugo.IsServer instead.
```
by just replacing
`.Site.IsServer => hugo.IsServer`