### PR TITLE
post tile to its own partial - fix tag clipping in index

### DIFF
--- a/themes/tailbliss/layouts/index.html
+++ b/themes/tailbliss/layouts/index.html
@@ -198,55 +198,7 @@
                 <div class="px-4 text-gray-900 dark:text-white not-prose dark:text-zinc-200">
                     <div class="grid gap-4 mx-auto mt-12 mb-4 lg:max-w-none md:grid-cols-3">
                         {{ range (.Paginator 3).Pages }}
-                        <div class="flex overflow-hidden flex-col bg-gray-50 rounded-lg shadow-lg dark:bg-gray-900">
-                            <a href="{{.Permalink}}">
-                                {{ with .Params.featured_image }}
-                                {{ with resources.Get . }}
-                                {{ $resized := .Resize "500x webp q90" }}
-                                <img src="{{ $resized.RelPermalink }}" class="object-fill overflow-hidden rounded-t-lg" width="{{ $resized.Width }}" height="{{ $resized.Height }}" loading="lazy" alt="{{ .Title }}" />
-
-                                {{ end }}
-                                {{ end }}
-                            </a>
-                            <div class="p-6">
-                                <div class="flex-1">
-                                    <a href="{{.Permalink}}" class="block mt-2 text-2xl font-black text-gray-900 dark:text-gray-200 hover:text-primary-600 dark:hover:text-primary-500 hover:underline">
-                                        {{ .Title }}
-                                    </a>
-                                    <p class="mt-3 text-base text-gray-900 dark:text-gray-300">
-                                        {{ .Params.summary }}
-                                    </p>
-                                </div>
-                                <div class="flex pt-6 font-medium text-primary-600 dark:text-primary-100 text-md">
-                                    <span class="pr-2 font-black">Tags:</span>
-                                    {{ range $elem_index, $elem_val := (.GetTerms "tags") }}
-                                    {{- if gt $elem_index 0 }}, {{ end -}}
-                                    <a href="{{ .Permalink }}" class="inline-flex items-center px-2.5 py-0.5 text-sm font-medium text-gray-900 bg-gray-300 rounded-md hover:bg-primary-200 hover:text-black">{{ .LinkTitle }}</a>
-                                    {{- end -}}
-                                </div>
-                                <div class="flex items-center mt-6">
-                                    <div class="flex-shrink-0">
-                                        <span class="sr-only">{{ .Params.author }}</span>
-                                        {{ with .Params.authorimage }}
-                                        {{ with resources.Get . }}
-                                        {{ $authorresized := .Resize "40x40 webp q75" }}
-                                        <img class="w-10 h-10 rounded-full" src="{{ $authorresized.RelPermalink }}" width="40" height="40" alt="" loading="lazy">
-                                        {{ end }}
-                                        {{ end }}
-                                    </div>
-                                    <div class="pt-1 ml-3">
-                                        <p class="text-sm font-medium text-gray-900 dark:text-white">
-                                            {{ .Params.author }}
-                                        </p>
-                                        <div class="flex space-x-1 text-sm text-gray-500 dark:text-white">
-                                            <time datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">{{ .Date.Format "2006-01-02" }}</time>
-                                            <span aria-hidden="true">&middot;</span>
-                                            <span>{{ math.Round (div (countwords .Content) 220.0) }} min read</span>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                            {{ partial "post-tile.html" . }}
                         {{ end }}
                     </div>
                 </div>

--- a/themes/tailbliss/layouts/partials/post-tile.html
+++ b/themes/tailbliss/layouts/partials/post-tile.html
@@ -1,0 +1,54 @@
+<div class="flex overflow-hidden flex-col bg-gray-50 rounded-lg shadow-lg dark:bg-gray-900">
+    <a href="{{.Permalink}}">
+        {{ with .Params.featured_image }}
+        {{ with resources.Get . }}
+        {{ $resized := .Resize "500x webp q90" }}
+        <img src="{{ $resized.RelPermalink }}" class="object-fill overflow-hidden rounded-t-lg" width="{{ $resized.Width }}" height="{{ $resized.Height }}"
+              loading="lazy" alt="{{ .Title }}" />
+
+        {{ end }}
+        {{ end }}
+    </a>
+    <div class="p-6">
+        <div class="flex-1">
+            <a href="{{.Permalink}}"
+                class="block mt-2 text-2xl font-black text-gray-900 dark:text-gray-200 hover:text-primary-600 dark:hover:text-primary-500 hover:underline">
+                {{.Title}}
+            </a>
+            <p class="mt-3 text-base text-gray-900 dark:text-gray-300">
+                {{ .Params.summary }}
+            </p>
+        </div>
+        <div class="flex pt-6 font-medium text-primary-600 dark:text-primary-100 text-md">
+            <span class="pr-2 font-black">Tags:</span>
+            <span>
+            {{ range $elem_index, $elem_val := (.GetTerms "tags") }}
+            {{- if gt $elem_index 0 }}, {{ end -}}
+            <a href="{{ .Permalink }}"
+                class="inline-flex items-center px-2.5 py-0.5 text-sm font-medium text-gray-900 capitalize bg-gray-300 rounded-md hover:bg-primary-200 hover:text-black">{{ .LinkTitle }}</a>
+            {{- end -}}
+            </span>
+        </div>
+        <div class="flex items-center mt-6">
+            <div class="flex-shrink-0">
+                <span class="sr-only">{{ .Params.author }}</span>
+                {{ with .Params.authorimage }}
+                {{ with resources.Get . }}
+                {{ $authorresized := .Resize "40x40 webp q75" }}
+                <img class="w-10 h-10 rounded-full" src="{{ $authorresized.RelPermalink }}" width="40" height="40" alt="" loading="lazy">
+                {{ end }}
+                {{ end }}
+            </div>
+            <div class="pt-1 ml-3">
+                <p class="text-sm font-medium text-gray-900 dark:text-white">
+                    {{ .Params.author }}
+                </p>
+                <div class="flex space-x-1 text-sm text-gray-500 dark:text-white">
+                    <time datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">{{ .Date.Format "2006-01-02" }}</time>
+                    <span aria-hidden="true">&middot;</span>
+                    <span>{{ math.Round (div (countwords .Content) 220.0) }} min read</span>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/themes/tailbliss/layouts/partials/posts-template.html
+++ b/themes/tailbliss/layouts/partials/posts-template.html
@@ -2,60 +2,7 @@
     <div class="px-4 not-prose">
         <div class="grid gap-4 mx-auto mt-12 mb-4 lg:max-w-none md:grid-cols-3">
             {{ range .Paginator.Pages }}
-            <div class="flex overflow-hidden flex-col bg-gray-50 rounded-lg shadow-lg dark:bg-gray-900">
-                <a href="{{.Permalink}}">
-                    {{ with .Params.featured_image }}
-                    {{ with resources.Get . }}
-                    {{ $resized := .Resize "500x webp q90" }}
-                    <img src="{{ $resized.RelPermalink }}" class="object-fill overflow-hidden rounded-t-lg" width="{{ $resized.Width }}" height="{{ $resized.Height }}"
-                         loading="lazy" alt="{{ .Title }}" />
-
-                    {{ end }}
-                    {{ end }}
-                </a>
-                <div class="p-6">
-                    <div class="flex-1">
-                        <a href="{{.Permalink}}"
-                           class="block mt-2 text-2xl font-black text-gray-900 dark:text-gray-200 hover:text-primary-600 dark:hover:text-primary-500 hover:underline">
-                            {{.Title}}
-                        </a>
-                        <p class="mt-3 text-base text-gray-900 dark:text-gray-300">
-                            {{ .Params.summary }}
-                        </p>
-                    </div>
-                    <div class="flex pt-6 font-medium text-primary-600 dark:text-primary-100 text-md">
-                        <span class="pr-2 font-black">Tags:</span>
-                        <span>
-                        {{ range $elem_index, $elem_val := (.GetTerms "tags") }}
-                        {{- if gt $elem_index 0 }}, {{ end -}}
-                        <a href="{{ .Permalink }}"
-                           class="inline-flex items-center px-2.5 py-0.5 text-sm font-medium text-gray-900 capitalize bg-gray-300 rounded-md hover:bg-primary-200 hover:text-black">{{ .LinkTitle }}</a>
-                        {{- end -}}
-                        </span>
-                    </div>
-                    <div class="flex items-center mt-6">
-                        <div class="flex-shrink-0">
-                            <span class="sr-only">{{ .Params.author }}</span>
-                            {{ with .Params.authorimage }}
-                            {{ with resources.Get . }}
-                            {{ $authorresized := .Resize "40x40 webp q75" }}
-                            <img class="w-10 h-10 rounded-full" src="{{ $authorresized.RelPermalink }}" width="40" height="40" alt="" loading="lazy">
-                            {{ end }}
-                            {{ end }}
-                        </div>
-                        <div class="pt-1 ml-3">
-                            <p class="text-sm font-medium text-gray-900 dark:text-white">
-                                {{ .Params.author }}
-                            </p>
-                            <div class="flex space-x-1 text-sm text-gray-500 dark:text-white">
-                                <time datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">{{ .Date.Format "2006-01-02" }}</time>
-                                <span aria-hidden="true">&middot;</span>
-                                <span>{{ math.Round (div (countwords .Content) 220.0) }} min read</span>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
+                {{ partial "post-tile.html" . }}
             {{ end }}
         </div>
     </div>


### PR DESCRIPTION
I noticed when I was working on my own site that the post tile on the index page would not wrap the tags if they extended outside of the post tile preview, but did wrap in the posts-template. An easy fix was to turn the tile into its own partial and be consumed. This adds consistency and reduces the code you need to maintain.